### PR TITLE
doc: add missing install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can install `eh` with git, like so
 
     git clone git@github.com:Frost/eh.git
     cd eh
+    mix deps.get
     mix escript.build
     ./eh Eh
 


### PR DESCRIPTION
`mix escript.build` fails without dependencies.
